### PR TITLE
Parse azure-integration metadata through a json parser

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   call-inclusive-naming-check:
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
 
@@ -13,6 +13,6 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11', '3.12']"
+      python: "['3.8','3.10','3.12']"
     needs:
       - call-inclusive-naming-check 

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -14,9 +14,11 @@ import os
 
 
 class MyCharm(ops.CharmBase):
-    azure_meta = ops.RelationMeta(
-        ops.RelationRole.requires, "azure", {"interface": "azure-integration"}
-    )
+    azure_meta = """
+requires:
+    azure:
+        interface: azure-integration
+"""
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -33,11 +35,8 @@ def juju_enviro():
 
 @pytest.fixture(scope="function")
 def harness():
-    harness = ops.testing.Harness(MyCharm)
+    harness = ops.testing.Harness(MyCharm, meta=MyCharm.azure_meta)
     harness.framework.meta.name = "test"
-    harness.framework.meta.relations = {
-        MyCharm.azure_meta.relation_name: MyCharm.azure_meta
-    }
     harness.set_model_name("test/0")
     harness.begin_with_initial_hooks()
     yield harness
@@ -152,6 +151,6 @@ def test_request_simple(harness, method_name, args, sent_data):
         ("tenant_id", "ti"),
     ],
 )
-def test_received_data(harness, method_name, expected, integrator_data):
-    harness.add_relation("azure", "remote", unit_data=integrator_data)
+def test_received_data(harness: ops.testing.Harness, method_name, expected, integrator_data):
+    harness.add_relation("azure", "remote/0", unit_data=integrator_data)
     assert getattr(harness.charm.azure, method_name) == expected

--- a/ops/tests/unit/test_ops_requires.py
+++ b/ops/tests/unit/test_ops_requires.py
@@ -151,6 +151,8 @@ def test_request_simple(harness, method_name, args, sent_data):
         ("tenant_id", "ti"),
     ],
 )
-def test_received_data(harness: ops.testing.Harness, method_name, expected, integrator_data):
+def test_received_data(
+    harness: ops.testing.Harness, method_name, expected, integrator_data
+):
     harness.add_relation("azure", "remote/0", unit_data=integrator_data)
     assert getattr(harness.charm.azure, method_name) == expected


### PR DESCRIPTION
### Overview
Parse relation databag items with a json decoder

Resolves [LP#2074263](https://bugs.launchpad.net/charm-azure-cloud-provider/+bug/2074263)

### Details
The azure secret data ended up with json junk in it -- preventing the cloud provider controller manager from starting successfully.  

* Adjust the received data by running it through an optional json parser. 
* Update the woke workflow
* Updated unit test harness metadata